### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/hildebrandglow_dcc/sensor.py
+++ b/custom_components/hildebrandglow_dcc/sensor.py
@@ -134,9 +134,9 @@ def device_name(resource, virtual_entity) -> str:
 
 
 async def should_update() -> bool:
-    """Check if time is between 0-5 or 30-35 minutes past the hour."""
+    """Check if time is between 1-5 or 31-35 minutes past the hour."""
     minutes = datetime.now().minute
-    if (0 <= minutes <= 5) or (30 <= minutes <= 35):
+    if (1 <= minutes <= 5) or (31 <= minutes <= 35):
         return True
     return False
 


### PR DESCRIPTION
Ensure that should_update only triggers in minutes 1-5 and 31-35 past the hour

<!--- Provide a general summary of your changes in the Title above -->

## Description
Current code will trigger twice in six minutes if 5 min schedule is 0,5,10... to 55. Change to code ensures triggers only once

## Motivation and Context
This stops the data request from triggering twice in six minutes
Fixes issue [#361](https://github.com/HandyHat/ha-hildebrandglow-dcc/issues/361) 

## How Has This Been Tested?
This was tested by making the change on my system and restarting the instance at exactly zero minutes on the hour, before the change I'd get data requested at 0, 5, 30, & 35 minutes past the hour, afterwards just at 0 & 30.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
